### PR TITLE
Fixed patch bug with Movie endpoint

### DIFF
--- a/afh-api/Controllers/MovieController.cs
+++ b/afh-api/Controllers/MovieController.cs
@@ -59,7 +59,7 @@ namespace afh_be.Controllers
 
             try
             {
-                await _movieLibrary.EditMovie(updatedMovie);
+                await _movieLibrary.EditMovie(updatedMovie, existingMovie);
                 return NoContent();
             }
             catch (Exception)

--- a/afh-api/Controllers/MovieController.cs
+++ b/afh-api/Controllers/MovieController.cs
@@ -38,11 +38,11 @@ namespace afh_be.Controllers
         }
 
         [HttpPost("")]
-        public async Task AddMovie([FromBody] Movie movie)
+        public async Task AddMovie([FromBody] Movie newMovie)
         {
-            if (movie != null)
+            if (newMovie != null)
             {
-                await _movieLibrary.AddMovie(movie);
+                await _movieLibrary.AddMovie(newMovie);
             }
             return;
         }

--- a/afh-api/Controllers/MovieController.cs
+++ b/afh-api/Controllers/MovieController.cs
@@ -50,10 +50,8 @@ namespace afh_be.Controllers
         [HttpPatch("{id}")]
         public async Task<IActionResult> EditMovie([FromBody] Movie updatedMovie, int id)
         {
-            // Find the existing movie by id
             var existingMovie = await _movieLibrary.GetMovieById(id);
 
-            // Check if the movie exists
             if (existingMovie == null)
             {
                 return NotFound(); // Return 404 Not Found if movie with id not found

--- a/afh-db/Libraries/IMovieLibrary.cs
+++ b/afh-db/Libraries/IMovieLibrary.cs
@@ -9,7 +9,7 @@ public interface IMovieLibrary
     Task DeleteMovie(Movie movie);
     Task<List<Movie>> GetMoviesList();
     Task AddMovie(Movie newMovie);
-    Task EditMovie(Movie movie);
+    Task EditMovie(Movie editMovie, Movie existingMovie);
 }
 
 public class MovieLibrary : IMovieLibrary
@@ -43,10 +43,16 @@ public class MovieLibrary : IMovieLibrary
         await _context.SaveChangesAsync();
     }
 
-    public async Task EditMovie(Movie movie)
+    public async Task EditMovie(Movie editMovie, Movie existingMovie)
     {
-        // Save changes to the database
-        _context.Movies.Update(movie);
+        foreach (var property in editMovie.GetType().GetProperties())
+        {
+            var value = property.GetValue(editMovie);
+            if (value != null)
+            {
+                _context.Entry(existingMovie).Property(property.Name).CurrentValue = value;
+            }
+        }
         await _context.SaveChangesAsync();
     }
 }

--- a/afh-db/Libraries/IMovieLibrary.cs
+++ b/afh-db/Libraries/IMovieLibrary.cs
@@ -8,7 +8,7 @@ public interface IMovieLibrary
     Task<Movie?> GetMovieById(int id);
     Task DeleteMovie(Movie movie);
     Task<List<Movie>> GetMoviesList();
-    Task AddMovie(Movie movie);
+    Task AddMovie(Movie newMovie);
     Task EditMovie(Movie movie);
 }
 
@@ -37,9 +37,9 @@ public class MovieLibrary : IMovieLibrary
         return await _context.Movies.ToListAsync();
     }
 
-    public async Task AddMovie(Movie movie)
+    public async Task AddMovie(Movie newMovie)
     {
-        await _context.Movies.AddAsync(movie);
+        await _context.Movies.AddAsync(newMovie);
         await _context.SaveChangesAsync();
     }
 


### PR DESCRIPTION
Movies can now be editted successfully. 

Also changed the name of args for ```AddMovie([FromBody] Movie newMovie)```. I changed it to newMovie instead of movie to make it clear and differentiate it from the class.