### PR TITLE
Restrict movie properties in api

### DIFF
--- a/afh-api/Controllers/MovieController.cs
+++ b/afh-api/Controllers/MovieController.cs
@@ -2,7 +2,10 @@
 using afh_db;
 using afh_db.Libraries;
 using afh_db.Models;
+using afh_api.DTOs;
+using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 using Microsoft.EntityFrameworkCore;
 
 namespace afh_be.Controllers
@@ -12,19 +15,25 @@ namespace afh_be.Controllers
     public class MovieController : ControllerBase
     {
         private readonly IMovieLibrary _movieLibrary;
+        private readonly IMapper _mapper;
 
-        public MovieController(IMovieLibrary movieLibrary)
+        public MovieController(IMovieLibrary movieLibrary, IMapper mapper)
         {
             _movieLibrary = movieLibrary;
+            _mapper = mapper;
         }
 
         [HttpGet]
+        [SwaggerResponse(200, "Success", typeof(MovieDto))]
         public async Task<ActionResult<IEnumerable<Movie>>> GetMoviesList()
         {
-            return await _movieLibrary.GetMoviesList();
+            var movies = await _movieLibrary.GetMoviesList();
+            var movieDto = _mapper.Map<MovieDto>(movies);
+            return Ok(movieDto);
         }
 
         [HttpGet("{id}")]
+        [SwaggerResponse(200, "Success", typeof(MovieDto))]
         public async Task<ActionResult<Movie>> GetMovieById(int id)
         {
             var movie = await _movieLibrary.GetMovieById(id);
@@ -34,7 +43,9 @@ namespace afh_be.Controllers
                 return NotFound();
             }
 
-            return movie;
+             var movieDto = _mapper.Map<MovieDto>(movie);
+
+            return Ok(movieDto);
         }
 
         [HttpPost("")]

--- a/afh-api/Controllers/MovieController.cs
+++ b/afh-api/Controllers/MovieController.cs
@@ -28,7 +28,7 @@ namespace afh_be.Controllers
         public async Task<ActionResult<IEnumerable<Movie>>> GetMoviesList()
         {
             var movies = await _movieLibrary.GetMoviesList();
-            var movieDto = _mapper.Map<MovieDto>(movies);
+            var movieDto = _mapper.Map<IEnumerable<MovieDto>>(movies);
             return Ok(movieDto);
         }
 
@@ -49,10 +49,12 @@ namespace afh_be.Controllers
         }
 
         [HttpPost("")]
+        // [SwaggerResponse(200, "Success", typeof(MovieDto))]
         public async Task AddMovie([FromBody] Movie newMovie)
         {
             if (newMovie != null)
             {
+                // var movieDto = _mapper.Map<MovieDto>(newMovie);
                 await _movieLibrary.AddMovie(newMovie);
             }
             return;

--- a/afh-api/Controllers/MovieController.cs
+++ b/afh-api/Controllers/MovieController.cs
@@ -48,16 +48,19 @@ namespace afh_be.Controllers
             return Ok(movieDto);
         }
 
-        [HttpPost("")]
-        // [SwaggerResponse(200, "Success", typeof(MovieDto))]
-        public async Task AddMovie([FromBody] Movie newMovie)
+        [HttpPost]
+        [SwaggerResponse(204, "No Content")]
+        public async Task<IActionResult> AddMovie([FromBody] AddMovieDto newMovieDto)
         {
-            if (newMovie != null)
+            if (newMovieDto != null)
             {
-                // var movieDto = _mapper.Map<MovieDto>(newMovie);
-                await _movieLibrary.AddMovie(newMovie);
+
+            var movieDto = _mapper.Map<Movie>(newMovieDto);
+            await _movieLibrary.AddMovie(movieDto);
+            return NoContent();
             }
-            return;
+
+            return BadRequest("Movie data is null");
         }
 
         [HttpPatch("{id}")]

--- a/afh-api/DTOs/MovieDto.cs
+++ b/afh-api/DTOs/MovieDto.cs
@@ -1,0 +1,13 @@
+namespace afh_api.DTOs
+{
+  public class MovieDto
+    {
+        public string? Title { get; set; }
+        public string? Length { get; set; }
+        public string? Description { get; set; }
+        public string? Genre { get; set; }
+        public string? Image { get; set; }        
+        public int Rating { get; set; }
+        public ICollection<CollectionMovie>? CollectionMovies { get; set; }
+    }
+}

--- a/afh-api/DTOs/MovieDto.cs
+++ b/afh-api/DTOs/MovieDto.cs
@@ -10,4 +10,13 @@ namespace afh_api.DTOs
         public int Rating { get; set; }
         public ICollection<CollectionMovie>? CollectionMovies { get; set; }
     }
+
+    public class AddMovieDto {
+       public string? Title { get; set; }
+        public string? Length { get; set; }
+        public string? Description { get; set; }
+        public string? Genre { get; set; }
+        public string? Image { get; set; }        
+        public int Rating { get; set; }
+    }
 }

--- a/afh-api/DTOs/MovieDto.cs
+++ b/afh-api/DTOs/MovieDto.cs
@@ -2,6 +2,7 @@ namespace afh_api.DTOs
 {
   public class MovieDto
     {
+        public int MovieID { get; set; }
         public string? Title { get; set; }
         public string? Length { get; set; }
         public string? Description { get; set; }

--- a/afh-api/Mappings/MappingProfile.cs
+++ b/afh-api/Mappings/MappingProfile.cs
@@ -9,6 +9,7 @@ namespace afh_api.Mappings
         public MappingProfile()
         {
             CreateMap<User, UserDto>();
+            CreateMap<Movie, MovieDto>();
         }
     }
 }

--- a/afh-api/Mappings/MappingProfile.cs
+++ b/afh-api/Mappings/MappingProfile.cs
@@ -10,6 +10,7 @@ namespace afh_api.Mappings
         {
             CreateMap<User, UserDto>();
             CreateMap<Movie, MovieDto>();
+            CreateMap<AddMovieDto, Movie>();
         }
     }
 }


### PR DESCRIPTION
When in Swagger and using the following endpoints: 
Get Movie
Get MovieId
The body shouldn't contain MovieId and CreatedAt. 

Post Movie
The body shouldn't have MovieId, CreatedAt and Collections

